### PR TITLE
Remove help keyword

### DIFF
--- a/EntityModel/DbModel.cs
+++ b/EntityModel/DbModel.cs
@@ -36,8 +36,8 @@ namespace EntityModel
         public DbModel CreateDbContext(string[] args)
         {
             // Only used by EF Core Tools, so okay to hardcode to local DB.
-            //return Create("Server=(LocalDb)\\MSSQLLocalDB;initial catalog=ProjectTira;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework");
-            return Create("Server=tcp:project-tira-staging.database.windows.net,1433;Initial Catalog=project-tira-staging;Persist Security Info=False;User ID=project-tira;Password=LamePassword1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;");
+            return Create("Server=(LocalDb)\\MSSQLLocalDB;initial catalog=ProjectTira;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework");
+            //return Create("Server=tcp:project-tira-staging.database.windows.net,1433;Initial Catalog=project-tira-staging;Persist Security Info=False;User ID=project-tira;Password=LamePassword1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;");
         }
 
         public static DbModel Create(string connectionString)

--- a/EntityModel/DbModel.cs
+++ b/EntityModel/DbModel.cs
@@ -36,8 +36,8 @@ namespace EntityModel
         public DbModel CreateDbContext(string[] args)
         {
             // Only used by EF Core Tools, so okay to hardcode to local DB.
-            return Create("Server=(LocalDb)\\MSSQLLocalDB;initial catalog=ProjectTira;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework");
-            //return Create("Server=tcp:project-tira-staging.database.windows.net,1433;Initial Catalog=project-tira-staging;Persist Security Info=False;User ID=project-tira;Password=LamePassword1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;");
+            //return Create("Server=(LocalDb)\\MSSQLLocalDB;initial catalog=ProjectTira;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework");
+            return Create("Server=tcp:project-tira-staging.database.windows.net,1433;Initial Catalog=project-tira-staging;Persist Security Info=False;User ID=project-tira;Password=LamePassword1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;");
         }
 
         public static DbModel Create(string connectionString)

--- a/ServiceProviderBot/Bot/Dialogs/MasterDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/MasterDialog.cs
@@ -53,7 +53,6 @@ namespace ServiceProviderBot.Bot.Dialogs
                     if (!string.IsNullOrEmpty(incomingMessage))
                     {
                         bool isKeyword =
-                            string.Equals(incomingMessage, Phrases.Greeting.HelpKeyword, StringComparison.OrdinalIgnoreCase) ||
                             string.Equals(incomingMessage, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase) ||
                             string.Equals(incomingMessage, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase) ||
                             string.Equals(incomingMessage, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase);
@@ -74,11 +73,10 @@ namespace ServiceProviderBot.Bot.Dialogs
                 {
                     var result = stepContext.Result as string;
 
-                    if (string.Equals(result, Phrases.Greeting.HelpKeyword, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(result, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase))
                     {
-                        // Show help dialog.
-                        await Messages.SendAsync(Phrases.Greeting.Help, stepContext.Context, cancellationToken);
-                        return await stepContext.EndDialogAsync(cancellationToken);
+                        // Push the update organization dialog onto the stack.
+                        return await BeginDialogAsync(stepContext, UpdateOrganizationDialog.Name, null, cancellationToken);
                     }
                     else if (string.Equals(result, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase) ||
                         string.Equals(result, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase))
@@ -95,24 +93,6 @@ namespace ServiceProviderBot.Bot.Dialogs
 
                         await Messages.SendAsync(Phrases.Greeting.ContactUpdated(user.ContactEnabled), stepContext.Context, cancellationToken);
                         return await stepContext.EndDialogAsync(cancellationToken);
-                    }
-                    else if (string.Equals(result, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Disable contact.
-                        var user = await api.GetUser(Helpers.GetUserToken(stepContext.Context));
-                        if (user.ContactEnabled)
-                        {
-                            user.ContactEnabled = false;
-                            await this.api.Update(user);
-                        }
-
-                        await Messages.SendAsync(Phrases.Greeting.ContactUpdated(user.ContactEnabled), stepContext.Context, cancellationToken);
-                        return await stepContext.EndDialogAsync(cancellationToken);
-                    }
-                    else if (string.Equals(result, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Push the update organization dialog onto the stack.
-                        return await BeginDialogAsync(stepContext, UpdateOrganizationDialog.Name, null, cancellationToken);
                     }
 
                     return await stepContext.NextAsync(cancellationToken);

--- a/ServiceProviderBot/Bot/Prompts/GreetingPromptValidator.cs
+++ b/ServiceProviderBot/Bot/Prompts/GreetingPromptValidator.cs
@@ -13,8 +13,7 @@ namespace ServiceProviderBot.Bot.Prompts
             {
                 var message = promptContext.Recognized.Value;
 
-                if (string.Equals(message, Phrases.Greeting.HelpKeyword, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(message, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase) ||
+                if (string.Equals(message, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(message, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(message, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase))
                 {

--- a/Shared/Phrases.cs
+++ b/Shared/Phrases.cs
@@ -33,7 +33,7 @@ namespace Shared
 
             public static Activity Keywords(bool contactEnabled)
             {
-                return MessageFactory.Text("Options:" + Environment.NewLine +
+                return MessageFactory.Text(
                     "- " + Update + Environment.NewLine +
                     "- " + (contactEnabled ? Disable : Enable) + Environment.NewLine);
             }

--- a/Shared/Phrases.cs
+++ b/Shared/Phrases.cs
@@ -12,18 +12,17 @@ namespace Shared
 
         public static class Greeting
         {
-            public static string HelpKeyword = "info";
+            public static string UpdateKeyword = "update";
             public static string EnableKeyword = "enable";
             public static string DisableKeyword = "disable";
-            public static string UpdateKeyword = "update";
 
             private static string Enable = $"Send \"{EnableKeyword}\" to allow the {ProjectName} bot to contact you for your availability";
             private static string Disable = $"Send \"{DisableKeyword}\" to stop the {ProjectName} bot from contacting you for your availability";
+            private static string Update = $"Send \"{UpdateKeyword}\" to update your availability";
 
             public static Activity NotRegistered = MessageFactory.Text($"It looks like you aren't registered - Visit {WebsiteUrl} to register and link your mobile phone number");
             public static Activity NoOrganization = MessageFactory.Text($"It looks like you aren't connected with an organization. Visit {WebsiteUrl} to register your organization");
             public static Activity UnverifiedOrganization = MessageFactory.Text("It looks like your organization is still pending verification. You will be notified once your organization is verified");
-            public static Activity Help = MessageFactory.Text($"{ProjectName} is a Trafficking Interruption Resource Agent that provides a near-realtime view of available resources. Visit {WebsiteUrl} for more info");
             public static Activity TimeToUpdate = MessageFactory.Text($"It's time to update! Send \"{UpdateKeyword}\" when you are ready to begin");
 
             public static Activity Welcome(User user)
@@ -34,9 +33,9 @@ namespace Shared
 
             public static Activity Keywords(bool contactEnabled)
             {
-                return MessageFactory.Text($"Send \"{UpdateKeyword}\" to update your organization's current capacity" + Environment.NewLine +
-                                           (contactEnabled ? Disable : Enable) + Environment.NewLine +
-                                           $"Send \"{HelpKeyword}\" for more information");
+                return MessageFactory.Text("Options:" + Environment.NewLine +
+                    "- " + Update + Environment.NewLine +
+                    "- " + (contactEnabled ? Disable : Enable) + Environment.NewLine);
             }
 
             public static Activity ContactUpdated(bool contactEnabled)

--- a/Tests/Dialogs/MasterDialogTests.cs
+++ b/Tests/Dialogs/MasterDialogTests.cs
@@ -40,19 +40,6 @@ namespace Tests.Dialogs
         }
 
         [Fact]
-        public async Task Help()
-        {
-            var organization = await TestHelpers.CreateOrganization(this.api, isVerified: true);
-            var user = await TestHelpers.CreateUser(this.api, organization.Id);
-
-            await CreateTestFlow(MasterDialog.Name, user)
-                .Send(Phrases.Greeting.HelpKeyword)
-                .AssertReply(Phrases.Greeting.Welcome(user))
-                .AssertReply(Phrases.Greeting.Help)
-                .StartTestAsync();
-        }
-
-        [Fact]
         public async Task Enable()
         {
             var organization = await TestHelpers.CreateOrganization(this.api, isVerified: true);


### PR DESCRIPTION
Both "help" and "info" are caught by Twilio, so they don't make it through to the bot. The help prompt isn't really needed at this point, since if the user isn't registered or doesn't have an organization they are directed to the portal, and if an invalid keyword is entered, the user is told what the valid keywords are.