### PR TITLE
Handle expired conversations

### DIFF
--- a/ServiceProviderBot/Bot/Dialogs/MasterDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/MasterDialog.cs
@@ -13,8 +13,8 @@ namespace ServiceProviderBot.Bot.Dialogs
     {
         public static string Name = typeof(MasterDialog).FullName;
 
-        public MasterDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public MasterDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {
@@ -23,7 +23,7 @@ namespace ServiceProviderBot.Bot.Dialogs
                 async (stepContext, cancellationToken) =>
                 {
                     // Check if the user is already registered.
-                    var user = await api.GetUser(Helpers.GetUserToken(stepContext.Context));
+                    var user = await api.GetUser(this.userToken);
                     if (user == null)
                     {
                         await Messages.SendAsync(Phrases.Greeting.NotRegistered, stepContext.Context, cancellationToken);
@@ -31,7 +31,7 @@ namespace ServiceProviderBot.Bot.Dialogs
                     }
 
                     // Check if we already have an organization for the user.
-                    var organization = await api.GetOrganization(Helpers.GetUserToken(stepContext.Context));
+                    var organization = await api.GetOrganization(this.userToken);
                     if (organization == null)
                     {
                         await Messages.SendAsync(Phrases.Greeting.NoOrganization, stepContext.Context, cancellationToken);
@@ -84,7 +84,7 @@ namespace ServiceProviderBot.Bot.Dialogs
                         // Enable/disable contact.
                         var enable = string.Equals(result, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase);
 
-                        var user = await api.GetUser(Helpers.GetUserToken(stepContext.Context));
+                        var user = await api.GetUser(this.userToken);
                         if (user.ContactEnabled != enable)
                         {
                             user.ContactEnabled = enable;

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateCapacityDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateCapacityDialog.cs
@@ -10,8 +10,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
     {
         public static string Name = typeof(UpdateCapacityDialog).FullName;
 
-        public UpdateCapacityDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateCapacityDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {
@@ -21,7 +21,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
                 async (stepContext, cancellationToken) =>
                 {
                     // Check if the organization has case management services.
-                    var service = await api.GetService<CaseManagementData>(Helpers.GetUserToken(stepContext.Context));
+                    var service = await api.GetService<CaseManagementData>(this.userToken);
                     if (service != null)
                     {
                         // Push the update case management dialog onto the stack.
@@ -34,7 +34,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
                 async (stepContext, cancellationToken) =>
                 {
                     // Check if the organization has housing services.
-                    var service = await api.GetService<HousingData>(Helpers.GetUserToken(stepContext.Context));
+                    var service = await api.GetService<HousingData>(this.userToken);
                     if (service != null)
                     {
                         // Push the update housing dialog onto the stack.
@@ -47,7 +47,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
                 async (stepContext, cancellationToken) =>
                 {
                     // Check if the organization has job training services.
-                    var service = await api.GetService<JobTrainingData>(Helpers.GetUserToken(stepContext.Context));
+                    var service = await api.GetService<JobTrainingData>(this.userToken);
                     if (service != null)
                     {
                         // Push the update job training dialog onto the stack.
@@ -60,7 +60,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
                 async (stepContext, cancellationToken) =>
                 {
                     // Check if the organization has mental health services.
-                    var service = await api.GetService<MentalHealthData>(Helpers.GetUserToken(stepContext.Context));
+                    var service = await api.GetService<MentalHealthData>(this.userToken);
                     if (service != null)
                     {
                         // Push the update mental health dialog onto the stack.
@@ -73,7 +73,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
                 async (stepContext, cancellationToken) =>
                 {
                     // Check if the organization has substance use services.
-                    var service = await api.GetService<SubstanceUseData>(Helpers.GetUserToken(stepContext.Context));
+                    var service = await api.GetService<SubstanceUseData>(this.userToken);
                     if (service != null)
                     {
                         // Push the update substance use dialog onto the stack.

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateCaseManagementDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateCaseManagementDialog.cs
@@ -11,8 +11,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
     {
         public static string Name = typeof(UpdateCaseManagementDialog).FullName;
 
-        public UpdateCaseManagementDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateCaseManagementDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateHousingDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateHousingDialog.cs
@@ -12,8 +12,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
     {
         public static string Name = typeof(UpdateHousingDialog).FullName;
 
-        public UpdateHousingDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateHousingDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateJobTrainingDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateJobTrainingDialog.cs
@@ -11,8 +11,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
     {
         public static string Name = typeof(UpdateJobTrainingDialog).FullName;
 
-        public UpdateJobTrainingDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateJobTrainingDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateMentalHealthDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateMentalHealthDialog.cs
@@ -11,8 +11,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
     {
         public static string Name = typeof(UpdateMentalHealthDialog).FullName;
 
-        public UpdateMentalHealthDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateMentalHealthDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateSubstanceUseDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateSubstanceUseDialog.cs
@@ -11,8 +11,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
     {
         public static string Name = typeof(UpdateSubstanceUseDialog).FullName;
 
-        public UpdateSubstanceUseDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateSubstanceUseDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/UpdateOrganizationDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/UpdateOrganizationDialog.cs
@@ -13,8 +13,8 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
     {
         public static string Name = typeof(UpdateOrganizationDialog).FullName;
 
-        public UpdateOrganizationDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration)
-            : base(state, dialogs, api, configuration) { }
+        public UpdateOrganizationDialog(StateAccessors state, DialogSet dialogs, IApiInterface api, IConfiguration configuration, string userToken)
+            : base(state, dialogs, api, configuration, userToken) { }
 
         public override WaterfallDialog GetWaterfallDialog()
         {
@@ -23,7 +23,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
             {
                 async (stepContext, cancellationToken) =>
                 {
-                    var needsUpdate = await NeedsUpdate(state, api, stepContext.Context);
+                    var needsUpdate = await NeedsUpdate(state, api, stepContext.Context, this.userToken);
                     if (!needsUpdate)
                     {
                         // Nothing to update.
@@ -47,9 +47,9 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
             });
         }
 
-        private static async Task<bool> NeedsUpdate(StateAccessors state, IApiInterface api, ITurnContext context)
+        private static async Task<bool> NeedsUpdate(StateAccessors state, IApiInterface api, ITurnContext context, string userToken)
         {
-            var serviceCount = await api.GetServiceCount(Helpers.GetUserToken(context));
+            var serviceCount = await api.GetServiceCount(userToken);
             return serviceCount > 0;
         }
     }

--- a/ServiceProviderBot/Bot/StateAccessors.cs
+++ b/ServiceProviderBot/Bot/StateAccessors.cs
@@ -1,13 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System;
-using EntityModel;
+﻿using System;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Extensions.Configuration;
-using ServiceProviderBot.Bot.Utils;
+using Shared;
 
 namespace ServiceProviderBot.Bot
 {

--- a/ServiceProviderBot/Bot/TheBot.cs
+++ b/ServiceProviderBot/Bot/TheBot.cs
@@ -4,6 +4,8 @@ using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using ServiceProviderBot.Bot.Dialogs;
 using ServiceProviderBot.Bot.Prompts;
+using ServiceProviderBot.Bot.Utils;
+using Shared;
 using Shared.ApiInterface;
 using System;
 using System.Threading;
@@ -17,6 +19,7 @@ namespace ServiceProviderBot.Bot
         private readonly DialogSet dialogs;
         private readonly IApiInterface api;
         private readonly IConfiguration configuration;
+        private string userToken;
 
         public TheBot(IConfiguration configuration, StateAccessors state, EfInterface api)
         {
@@ -33,35 +36,37 @@ namespace ServiceProviderBot.Bot
 
         public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Establish context for our dialog from the turn context.
-            DialogContext dialogContext = await this.dialogs.CreateContextAsync(turnContext, cancellationToken);
+            this.userToken = Helpers.GetUserToken(turnContext);
 
-            // Create the master dialog.
-            var masterDialog = new MasterDialog(this.state, this.dialogs, this.api, this.configuration);
-
-            // Attempt to continue any existing conversation.
-            DialogTurnResult results = await masterDialog.ContinueDialogAsync(dialogContext, cancellationToken);
-            var startNewConversation = turnContext.Activity.Type == ActivityTypes.Message && results.Status == DialogTurnStatus.Empty;
-
-            /*
-            // Check if the conversation is expired.
-            var forceExpire = Phrases.TriggerReset(turnContext);
-            var expired = await this.database.CheckExpiredConversation(turnContext, forceExpire);
-
-            if (expired)
+            if (turnContext.Activity.Type == ActivityTypes.Message)
             {
-                await dialogContext.CancelAllDialogsAsync(cancellationToken);
-                await masterDialog.BeginDialogAsync(dialogContext, MasterDialog.Name, null, cancellationToken);
-            }
-            else if (startNewConversation)
-            {
-                await masterDialog.BeginDialogAsync(dialogContext, MasterDialog.Name, null, cancellationToken);
-            }
-            */
+                // Establish context for our dialog from the turn context.
+                DialogContext dialogContext = await this.dialogs.CreateContextAsync(turnContext, cancellationToken);
 
-            if (startNewConversation)
-            {
-                await masterDialog.BeginDialogAsync(dialogContext, MasterDialog.Name, null, cancellationToken);
+                // Check if the conversation is expired.
+                var forceExpire = Phrases.Reset.ShouldReset(this.configuration, turnContext);
+                var expired = await this.api.ClearIncompleteSnapshots(this.userToken, forceExpire);
+
+                if (expired)
+                {
+                    await dialogContext.CancelAllDialogsAsync(cancellationToken);
+
+                    var user = await api.GetUser(this.userToken);
+                    await Messages.SendAsync(forceExpire ? Phrases.Reset.Forced(user) : Phrases.Reset.Expired(user), turnContext, cancellationToken);
+                    return;
+                }
+
+                // Create the master dialog.
+                var masterDialog = new MasterDialog(this.state, this.dialogs, this.api, this.configuration, this.userToken);
+
+                // Attempt to continue any existing conversation.
+                DialogTurnResult results = await masterDialog.ContinueDialogAsync(dialogContext, cancellationToken);
+
+                // Start a new conversation if there isn't one already.
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await masterDialog.BeginDialogAsync(dialogContext, MasterDialog.Name, null, cancellationToken);
+                }
             }
         }
     }

--- a/Shared/ApiInterface/ApiInterface.cs
+++ b/Shared/ApiInterface/ApiInterface.cs
@@ -17,6 +17,11 @@ namespace Shared.ApiInterface
         Task<bool> Update<T>(T model) where T : ModelBase;
 
         /// <summary>
+        /// Deletes a model.
+        /// </summary>
+        Task<bool> Delete<T>(T model) where T : ModelBase;
+
+        /// <summary>
         /// Gets a user from a user token.
         /// </summary>
         Task<User> GetUser(string userToken);
@@ -51,6 +56,11 @@ namespace Shared.ApiInterface
         /// Gets all users for an organization.
         /// </summary>
         Task<List<User>> GetUsersForOrganization(Organization organization);
+
+        /// <summary>
+        /// Clears incomplete snapshots and returns whether or not the conversation was expired.
+        /// </summary>
+        Task<bool> ClearIncompleteSnapshots(string userToken, bool forceExpire);
     }
 
     public enum ServiceType

--- a/Shared/ConfigurationExtensions.cs
+++ b/Shared/ConfigurationExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
 
-namespace ServiceProviderBot.Bot.Utils
+namespace Shared
 {
     public static class ConfigurationExtensions
     {
@@ -46,11 +46,6 @@ namespace ServiceProviderBot.Bot.Utils
         private const string CosmosCollectionSettingName = "CosmosDb:Collection";
 
         /// <summary>
-        /// The name of the setting that contains the Azure Maps subscription key.
-        /// </summary>
-        private const string MapsKeySettingName = "MapsKey";
-
-        /// <summary>
         /// The name of the setting that contains the CosmosDB collection.
         /// </summary>
         private const string SnapshotCollectorConfigurationSettingName = "SnapshotCollectorConfiguration";
@@ -93,11 +88,6 @@ namespace ServiceProviderBot.Bot.Utils
         public static string CosmosCollection(this IConfiguration configuration)
         {
             return configuration.GetValue<string>(CosmosCollectionSettingName);
-        }
-
-        public static string MapsKey(this IConfiguration configuration)
-        {
-            return configuration.GetValue<string>(MapsKeySettingName);
         }
 
         public static IConfigurationSection SnapshotCollectorConfiguration(this IConfiguration configuration)

--- a/Shared/Phrases.cs
+++ b/Shared/Phrases.cs
@@ -1,6 +1,7 @@
 ﻿using EntityModel;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 using System;
 
 namespace Shared
@@ -16,9 +17,9 @@ namespace Shared
             public static string EnableKeyword = "enable";
             public static string DisableKeyword = "disable";
 
-            private static string Enable = $"Send \"{EnableKeyword}\" to allow the {ProjectName} bot to contact you for your availability";
-            private static string Disable = $"Send \"{DisableKeyword}\" to stop the {ProjectName} bot from contacting you for your availability";
-            private static string Update = $"Send \"{UpdateKeyword}\" to update your availability";
+            public static string Enable = $"Send \"{EnableKeyword}\" to allow the {ProjectName} bot to contact you for your availability";
+            public static string Disable = $"Send \"{DisableKeyword}\" to stop the {ProjectName} bot from contacting you for your availability";
+            public static string Update = $"Send \"{UpdateKeyword}\" to update your availability";
 
             public static Activity NotRegistered = MessageFactory.Text($"It looks like you aren't registered - Visit {WebsiteUrl} to register and link your mobile phone number");
             public static Activity NoOrganization = MessageFactory.Text($"It looks like you aren't connected with an organization. Visit {WebsiteUrl} to register your organization");
@@ -114,6 +115,27 @@ namespace Shared
         {
             public static Activity NothingToUpdate = MessageFactory.Text("It looks like there isn't anything to update!");
             public static Activity Closing = MessageFactory.Text("Thanks for the update!");
+        }
+
+        public static class Reset
+        {
+            public static string Keyword = "reset";
+            public static int TimeoutHours = 12;
+
+            public static Activity Expired(User user)
+            {
+                return MessageFactory.Text($"Your update expired after {TimeoutHours} hours.{Environment.NewLine}{Greeting.Keywords(user.ContactEnabled).Text}");
+            }
+
+            public static Activity Forced(User user)
+            {
+                return MessageFactory.Text($"Forced reset.{Environment.NewLine}{Greeting.Keywords(user.ContactEnabled).Text}");
+            }
+
+            public static bool ShouldReset(IConfiguration configuration, ITurnContext turnContext)
+            {
+                return !configuration.IsProduction() && string.Equals(turnContext.Activity.Text, Keyword, StringComparison.OrdinalIgnoreCase);
+            }
         }
     }
 }

--- a/Shared/TestHelpers.cs
+++ b/Shared/TestHelpers.cs
@@ -66,7 +66,7 @@ namespace Shared
             {
                 CreatedById = createdById,
                 ServiceId = serviceId,
-                IsComplete = true,
+                IsComplete = isComplete,
                 HasWaitlist = hasWaitlist,
                 Total = total
             };


### PR DESCRIPTION
Handle when conversations have expired (currently 12 hours) by removing any incomplete data.
Also some cleanup to inject the user token into each dialog, rather than having to query it everywhere