### PR TITLE
Allow updating a single service

### DIFF
--- a/EntityModel/Service.cs
+++ b/EntityModel/Service.cs
@@ -22,7 +22,7 @@ namespace EntityModel
         public string Name { get; set; }
 
         [JsonProperty(PropertyName = "tira_servicetype")]
-        public int Type { get; set; }
+        public ServiceType Type { get; set; }
 
         public class Resolver : ContractResolver<CaseManagementData>
         {
@@ -33,5 +33,15 @@ namespace EntityModel
                 AddMap(x => x.Id, "tira_serviceid");
             }
         }
+    }
+
+    public enum ServiceType : int
+    {
+        Invalid = 0,
+        Housing = 1,
+        CaseManagement = 2,
+        MentalHealth = 3,
+        SubstanceUse = 4,
+        JobTraining = 5
     }
 }

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/UpdateOrganizationDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/UpdateOrganizationDialog.cs
@@ -1,11 +1,12 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
+﻿using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Extensions.Configuration;
 using ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity;
+using ServiceProviderBot.Bot.Prompts;
 using ServiceProviderBot.Bot.Utils;
 using Shared;
 using Shared.ApiInterface;
+using System.Collections.Generic;
 
 namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
 {
@@ -23,8 +24,9 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
             {
                 async (stepContext, cancellationToken) =>
                 {
-                    var needsUpdate = await NeedsUpdate(state, api, stepContext.Context, this.userToken);
-                    if (!needsUpdate)
+                    var services = await this.api.GetServices(this.userToken);
+
+                    if (services.Count == 0)
                     {
                         // Nothing to update.
                         await Messages.SendAsync(Phrases.Update.NothingToUpdate, stepContext.Context, cancellationToken);
@@ -33,8 +35,43 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
                         return await stepContext.EndDialogAsync(cancellationToken);
                     }
 
+                    if (services.Count > 1)
+                    {
+                        // Give an option to update a specific service or all services.
+                        var choices = new List<Choice>();
+                        choices.Add(new Choice { Value = Phrases.Services.All });
+                        services.ForEach(s => choices.Add(new Choice { Value = Helpers.GetServiceName(s.Type) }));
+
+                        return await stepContext.PromptAsync(
+                            Prompt.ChoicePrompt,
+                            new PromptOptions() {
+                                Prompt = Phrases.Update.Options,
+                                Choices = choices
+                            },
+                            cancellationToken);
+                    }
+
+                    // Skip this step.
+                    return await stepContext.NextAsync(null, cancellationToken);
+                },
+                async (stepContext, cancellationToken) =>
+                {
+                    if (stepContext.Result != null)
+                    {
+                        // Push the specific dialog onto the stack if one was selected.
+                        switch (((FoundChoice)stepContext.Result).Value)
+                        {
+                            case Phrases.Services.CaseManagement.ServiceName: return await BeginDialogAsync(stepContext, UpdateCaseManagementDialog.Name, null, cancellationToken);
+                            case Phrases.Services.Housing.ServiceName: return await BeginDialogAsync(stepContext, UpdateHousingDialog.Name, null, cancellationToken);
+                            case Phrases.Services.JobTraining.ServiceName: return await BeginDialogAsync(stepContext, UpdateJobTrainingDialog.Name, null, cancellationToken);
+                            case Phrases.Services.MentalHealth.ServiceName: return await BeginDialogAsync(stepContext, UpdateMentalHealthDialog.Name, null, cancellationToken);
+                            case Phrases.Services.SubstanceUse.ServiceName: return await BeginDialogAsync(stepContext, UpdateSubstanceUseDialog.Name, null, cancellationToken);
+                        }
+                    }
+
                     // Push the update capacity dialog onto the stack.
                     return await BeginDialogAsync(stepContext, UpdateCapacityDialog.Name, null, cancellationToken);
+
                 },
                 async (stepContext, cancellationToken) =>
                 {
@@ -45,12 +82,6 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization
                     return await stepContext.EndDialogAsync(cancellationToken);
                 }
             });
-        }
-
-        private static async Task<bool> NeedsUpdate(StateAccessors state, IApiInterface api, ITurnContext context, string userToken)
-        {
-            var serviceCount = await api.GetServiceCount(userToken);
-            return serviceCount > 0;
         }
     }
 }

--- a/Shared/ApiInterface/ApiInterface.cs
+++ b/Shared/ApiInterface/ApiInterface.cs
@@ -30,11 +30,16 @@ namespace Shared.ApiInterface
         /// Gets the count of an organization's services from a user token.
         /// </summary>
         Task<int> GetServiceCount(string userToken);
-
+        
         /// <summary>
         /// Gets an organization's service by type from a user token.
         /// </summary>
         Task<Service> GetService<T>(string userToken) where T : ServiceModelBase;
+
+        /// <summary>
+        /// Gets all of an organization's services from a user token.
+        /// </summary>
+        Task<List<Service>> GetServices(string userToken);
 
         /// <summary>
         /// Gets the latest shapshot for a service from a user token.
@@ -56,15 +61,5 @@ namespace Shared.ApiInterface
         /// Clears incomplete snapshots and returns whether or not the conversation was expired.
         /// </summary>
         Task<bool> IsUpdateExpired(string userToken, bool forceExpire);
-    }
-
-    public enum ServiceType
-    {
-        Invalid = 0,
-        Housing = 1,
-        CaseManagement = 2,
-        MentalHealth = 3,
-        SubstanceUse = 4,
-        JobTraining = 5
     }
 }

--- a/Shared/ApiInterface/CdsInterface.cs
+++ b/Shared/ApiInterface/CdsInterface.cs
@@ -128,7 +128,7 @@ namespace Shared.ApiInterface
                 var type = Helpers.GetServiceType<T>();
                 if (type != ServiceType.Invalid)
                 {
-                    JObject response = await GetJsonData(Service.TABLE_NAME, $"$filter=_tira_organizationservicesid_value eq {organization.Id} and tira_servicetype eq {(int)type}");
+                    JObject response = await GetJsonData(Service.TABLE_NAME, $"$filter=_tira_organizationservicesid_value eq {organization.Id} and tira_servicetype eq {type}");
                     if (response != null && response["value"].HasValues)
                     {
                         return JsonConvert.DeserializeObject<Service>(response["value"][0].ToString(), GetJsonSettings(Service.Resolver.Instance));
@@ -137,6 +137,24 @@ namespace Shared.ApiInterface
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets all of an organization's services from a user token.
+        /// </summary>
+        public async Task<List<Service>> GetServices(string userToken)
+        {
+            Organization organization = await GetOrganization(userToken);
+            if (organization != null)
+            {
+                JObject response = await GetJsonData(Service.TABLE_NAME, $"$filter=_tira_organizationservicesid_value eq {organization.Id}");
+                if (response != null && response["value"].HasValues)
+                {
+                    return JsonConvert.DeserializeObject<List<Service>>(response["value"].ToString(), GetJsonSettings(User.Resolver.Instance));
+                }
+            }
+
+            return new List<Service>();
         }
 
         /// <summary>

--- a/Shared/ApiInterface/EfInterface.cs
+++ b/Shared/ApiInterface/EfInterface.cs
@@ -124,11 +124,25 @@ namespace Shared.ApiInterface
                 var type = Helpers.GetServiceType<T>();
                 if (type != ServiceType.Invalid)
                 {
-                    return await this.dbContext.Services.FirstOrDefaultAsync(s => s.OrganizationId == organization.Id && s.Type == (int)type);
+                    return await this.dbContext.Services.FirstOrDefaultAsync(s => s.OrganizationId == organization.Id && s.Type == type);
                 }
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets all of an organization's services from a user token.
+        /// </summary>
+        public async Task<List<Service>> GetServices(string userToken)
+        {
+            Organization organization = await GetOrganization(userToken);
+            if (organization != null)
+            {
+                return await this.dbContext.Services.Where(s => s.OrganizationId == organization.Id).ToListAsync();
+            }
+
+            return new List<Service>();
         }
 
         /// <summary>

--- a/Shared/Phrases.cs
+++ b/Shared/Phrases.cs
@@ -8,14 +8,14 @@ namespace Shared
 {
     public static class Phrases
     {
-        public static string ProjectName = "Project TIRA";
-        public static string WebsiteUrl = "tira.powerappsportals.com";
+        public const string ProjectName = "Project TIRA";
+        public const string WebsiteUrl = "tira.powerappsportals.com";
 
         public static class Greeting
         {
-            public static string UpdateKeyword = "update";
-            public static string EnableKeyword = "enable";
-            public static string DisableKeyword = "disable";
+            public const string UpdateKeyword = "update";
+            public const string EnableKeyword = "enable";
+            public const string DisableKeyword = "disable";
 
             public static string Enable = $"Send \"{EnableKeyword}\" to allow the {ProjectName} bot to contact you for your availability";
             public static string Disable = $"Send \"{DisableKeyword}\" to stop the {ProjectName} bot from contacting you for your availability";
@@ -79,8 +79,8 @@ namespace Shared
 
         public static class Reset
         {
-            public static string Keyword = "reset";
-            public static int TimeoutHours = 12;
+            public const string Keyword = "reset";
+            public const int TimeoutHours = 12;
 
             public static Activity Expired(User user)
             {
@@ -100,41 +100,49 @@ namespace Shared
 
         public static class Services
         {
+            public static string All = "All";
+
             public static class CaseManagement
             {
-                public static string Name = "case management";
+                public const string ServiceName = "Case Management";
+                public const string Name = "case management";
             }
 
             public static class Housing
             {
-                public static string EmergencySharedBeds = "emergency shared-space beds";
-                public static string EmergencyPrivateBeds = "emergency private beds";
-                public static string LongTermSharedBeds = "long-term shared-space beds";
-                public static string LongTermPrivateBeds = "long-term private beds";
+                public const string ServiceName = "Housing";
+                public const string EmergencySharedBeds = "emergency shared-space beds";
+                public const string EmergencyPrivateBeds = "emergency private beds";
+                public const string LongTermSharedBeds = "long-term shared-space beds";
+                public const string LongTermPrivateBeds = "long-term private beds";
             }
 
             public static class JobTraining
             {
-                public static string Name = "job training services";
+                public const string ServiceName = "Job Training";
+                public const string Name = "job training services";
             }
 
             public static class MentalHealth
             {
-                public static string InPatient = "mental health in-patient services";
-                public static string OutPatient = "mental health out-patient services";
+                public const string ServiceName = "Mental Health";
+                public const string InPatient = "mental health in-patient services";
+                public const string OutPatient = "mental health out-patient services";
             }
 
             public static class SubstanceUse
             {
-                public static string Detox = "substance use detox services";
-                public static string InPatient = "substance use in-patient services";
-                public static string OutPatient = "substance use out-patient services";
-                public static string Group = "substance use group services";
+                public const string ServiceName = "Substance Use";
+                public const string Detox = "substance use detox services";
+                public const string InPatient = "substance use in-patient services";
+                public const string OutPatient = "substance use out-patient services";
+                public const string Group = "substance use group services";
             }
         }
 
         public static class Update
         {
+            public static Activity Options = MessageFactory.Text("Which service(s) would you like to update?");
             public static Activity NothingToUpdate = MessageFactory.Text("It looks like there isn't anything to update!");
             public static Activity Closing = MessageFactory.Text("Thanks for the update!");
         }

--- a/Shared/TestHelpers.cs
+++ b/Shared/TestHelpers.cs
@@ -52,7 +52,7 @@ namespace Shared
                 Id = Guid.NewGuid().ToString(),
                 OrganizationId = organizationId,
                 Name = $"Test Service ({type.ToString()})",
-                Type = (int)type
+                Type = type
             };
 
             await api.Create(service);

--- a/Tests/Dialogs/MasterDialogTests.cs
+++ b/Tests/Dialogs/MasterDialogTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Dialogs
         public async Task NotRegistered()
         {
             await CreateTestFlow(MasterDialog.Name, user: null)
-                .Test("hi", Phrases.Greeting.NotRegistered)
+                .Test("test", Phrases.Greeting.NotRegistered)
                 .StartTestAsync();
         }
 
@@ -25,7 +25,7 @@ namespace Tests.Dialogs
             User user = await TestHelpers.CreateUser(this.api, organizationId: string.Empty);
 
             await CreateTestFlow(MasterDialog.Name, user)
-                .Test("hi", Phrases.Greeting.NoOrganization)
+                .Test("test", Phrases.Greeting.NoOrganization)
                 .StartTestAsync();
         }
 
@@ -36,7 +36,7 @@ namespace Tests.Dialogs
             var user = await TestHelpers.CreateUser(this.api, organization.Id);
 
             await CreateTestFlow(MasterDialog.Name, user)
-                .Test("hi", Phrases.Greeting.UnverifiedOrganization)
+                .Test("test", Phrases.Greeting.UnverifiedOrganization)
                 .StartTestAsync();
         }
 
@@ -107,7 +107,7 @@ namespace Tests.Dialogs
             var user = await TestHelpers.CreateUser(this.api, organization.Id);
 
             await CreateTestFlow(MasterDialog.Name, user)
-                .Test("hi", Phrases.Greeting.Keywords(user, welcomeUser: true))
+                .Test("test", Phrases.Greeting.Keywords(user, welcomeUser: true))
                 .Test(Phrases.Reset.Keyword, Phrases.Reset.Forced(user))
                 .StartTestAsync();
         }


### PR DESCRIPTION
If an organization has multiple services, the user will have the option to select if they want to update a single service or all services. If the organization only has a single service, the option will be skipped and the user will be prompted for the single service