### PR TITLE
Don't auto-expire conversations

### DIFF
--- a/ServiceProviderBot/Bot/Dialogs/MasterDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/MasterDialog.cs
@@ -50,9 +50,9 @@ namespace ServiceProviderBot.Bot.Dialogs
                     if (!string.IsNullOrEmpty(incomingMessage))
                     {
                         bool isKeyword =
-                            string.Equals(incomingMessage, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(incomingMessage, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(incomingMessage, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase);
+                            string.Equals(incomingMessage, Phrases.Keywords.Enable, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(incomingMessage, Phrases.Keywords.Disable, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(incomingMessage, Phrases.Keywords.Update, StringComparison.OrdinalIgnoreCase);
 
                         if (isKeyword)
                         {
@@ -64,8 +64,8 @@ namespace ServiceProviderBot.Bot.Dialogs
                     return await stepContext.PromptAsync(
                         Prompt.GreetingTextPrompt,
                         new PromptOptions {
-                            Prompt = Phrases.Greeting.Keywords(user, welcomeUser: true),
-                            RetryPrompt = Phrases.Greeting.Keywords(user)
+                            Prompt = Phrases.Greeting.GetKeywords(user, welcomeUser: true),
+                            RetryPrompt = Phrases.Greeting.GetKeywords(user)
                         },
                         cancellationToken);
                 },
@@ -73,16 +73,16 @@ namespace ServiceProviderBot.Bot.Dialogs
                 {
                     var result = stepContext.Result as string;
 
-                    if (string.Equals(result, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(result, Phrases.Keywords.Update, StringComparison.OrdinalIgnoreCase))
                     {
                         // Push the update organization dialog onto the stack.
                         return await BeginDialogAsync(stepContext, UpdateOrganizationDialog.Name, null, cancellationToken);
                     }
-                    else if (string.Equals(result, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(result, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(result, Phrases.Keywords.Enable, StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(result, Phrases.Keywords.Disable, StringComparison.OrdinalIgnoreCase))
                     {
                         // Enable/disable contact.
-                        var enable = string.Equals(result, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase);
+                        var enable = string.Equals(result, Phrases.Keywords.Enable, StringComparison.OrdinalIgnoreCase);
 
                         var user = await api.GetUser(this.userToken);
                         if (user.ContactEnabled != enable)

--- a/ServiceProviderBot/Bot/Prompts/GreetingPromptValidator.cs
+++ b/ServiceProviderBot/Bot/Prompts/GreetingPromptValidator.cs
@@ -13,9 +13,9 @@ namespace ServiceProviderBot.Bot.Prompts
             {
                 var message = promptContext.Recognized.Value;
 
-                if (string.Equals(message, Phrases.Greeting.UpdateKeyword, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(message, Phrases.Greeting.EnableKeyword, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(message, Phrases.Greeting.DisableKeyword, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(message, Phrases.Keywords.Update, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(message, Phrases.Keywords.Enable, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(message, Phrases.Keywords.Disable, StringComparison.OrdinalIgnoreCase))
                 {
                     return await Task.FromResult(true);
                 }

--- a/ServiceProviderBot/Bot/TheBot.cs
+++ b/ServiceProviderBot/Bot/TheBot.cs
@@ -47,30 +47,19 @@ namespace ServiceProviderBot.Bot
                 // Create the master dialog.
                 var masterDialog = new MasterDialog(this.state, this.dialogs, this.api, this.configuration, this.userToken);
 
+                // If the user sends the update keyword, clear the dialog stack and start a new update.
+                if (string.Equals(turnContext.Activity.Text, Phrases.Keywords.Update, StringComparison.OrdinalIgnoreCase))
+                {
+                    await dialogContext.CancelAllDialogsAsync(cancellationToken);
+                }
+
+                // Attempt to continue any existing conversation.
+                DialogTurnResult result = await masterDialog.ContinueDialogAsync(dialogContext, cancellationToken);
+
                 // Start a new conversation if there isn't one already.
-                if (dialogContext.Stack.Count == 0)
+                if (result.Status == DialogTurnStatus.Empty)
                 {
                     await masterDialog.BeginDialogAsync(dialogContext, MasterDialog.Name, null, cancellationToken);
-                }
-                else
-                {
-                    // Check if the conversation is expired.
-                    var forceExpire = Phrases.Reset.ShouldReset(this.configuration, turnContext);
-                    var expired = forceExpire || await this.api.IsUpdateExpired(this.userToken);
-
-                    if (expired)
-                    {
-                        await dialogContext.CancelAllDialogsAsync(cancellationToken);
-
-                        var user = await api.GetUser(this.userToken);
-                        await Messages.SendAsync(forceExpire ? Phrases.Reset.Forced(user) : Phrases.Reset.Expired(user), turnContext, cancellationToken);
-                    }
-                    else
-                    {
-                        // Attempt to continue any existing conversation.
-                        DialogTurnResult results = await masterDialog.ContinueDialogAsync(dialogContext, cancellationToken);
-                        Debug.Assert(results.Status != DialogTurnStatus.Empty, "Should have an existing conversation");
-                    }
                 }
             }
         }

--- a/ServiceProviderBot/Startup.cs
+++ b/ServiceProviderBot/Startup.cs
@@ -67,14 +67,15 @@ namespace ServiceProviderBot
                     Debug.WriteLine(exception.Message);
                     this.telemetry.TrackException(exception);
 
-                    await context.TraceActivityAsync("Bot exception", exception);
-                    await context.SendActivityAsync("Sorry, it looks like something went wrong.");
+                    await context.TraceActivityAsync("Exception", exception);
 
                     if (!configuration.IsProduction())
                     {
                         await context.SendActivityAsync(exception.Message);
                         await context.SendActivityAsync(exception.StackTrace);
                     }
+
+                    await context.SendActivityAsync(Phrases.ExceptionMessage);
                 };
 
                 // Auto-save the state after each turn.

--- a/Shared/ApiInterface/ApiInterface.cs
+++ b/Shared/ApiInterface/ApiInterface.cs
@@ -56,10 +56,5 @@ namespace Shared.ApiInterface
         /// Gets all users for an organization.
         /// </summary>
         Task<List<User>> GetUsersForOrganization(Organization organization);
-
-        /// <summary>
-        /// Returns whether or not the conversation is expired.
-        /// </summary>
-        Task<bool> IsUpdateExpired(string userToken);
     }
 }

--- a/Shared/ApiInterface/CdsInterface.cs
+++ b/Shared/ApiInterface/CdsInterface.cs
@@ -220,45 +220,6 @@ namespace Shared.ApiInterface
         }
 
         /// <summary>
-        /// Returns whether or not the conversation is expired.
-        /// </summary>
-        public async Task<bool> IsUpdateExpired(string userToken)
-        {
-            // Expires after 12 hours.
-            var expiration = DateTime.UtcNow.AddHours(-12);
-            bool isExpired = await IsServiceDataExpired<CaseManagementData>(userToken);
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<HousingData>(userToken);
-            }
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<JobTrainingData>(userToken);
-            }
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<MentalHealthData>(userToken);
-            }
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<SubstanceUseData>(userToken);
-            }
-
-            return isExpired;
-        }
-
-        private async Task<bool> IsServiceDataExpired<T>(string userToken) where T : ServiceModelBase, new()
-        {
-            var expiration = DateTime.UtcNow.AddHours(-Phrases.Reset.TimeoutHours);
-            var data = await GetLatestServiceData<T>(userToken, createdByUser: true);
-            return data != null && !data.IsComplete && data.CreatedOn < expiration;
-        }
-
-        /// <summary>
         /// Gets JSON data from the API.
         /// </summary>
         private async Task<JObject> GetJsonData(string tableName, string paramString)

--- a/Shared/ApiInterface/EfInterface.cs
+++ b/Shared/ApiInterface/EfInterface.cs
@@ -194,44 +194,5 @@ namespace Shared.ApiInterface
         {
             return await this.dbContext.Users.Where(u => u.OrganizationId == organization.Id).ToListAsync();
         }
-
-        /// <summary>
-        /// Returns whether or not the conversation is expired.
-        /// </summary>
-        public async Task<bool> IsUpdateExpired(string userToken)
-        {
-            // Expires after 12 hours.
-            var expiration = DateTime.UtcNow.AddHours(-12);
-            bool isExpired =  await IsServiceDataExpired<CaseManagementData>(userToken);
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<HousingData>(userToken);
-            }
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<JobTrainingData>(userToken);
-            }
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<MentalHealthData>(userToken);
-            }
-
-            if (!isExpired)
-            {
-                isExpired |= await IsServiceDataExpired<SubstanceUseData>(userToken);
-            }
-
-            return isExpired;
-        }
-
-        private async Task<bool> IsServiceDataExpired<T>(string userToken) where T : ServiceModelBase, new()
-        {
-            var expiration = DateTime.UtcNow.AddHours(-Phrases.Reset.TimeoutHours);
-            var data = await GetLatestServiceData<T>(userToken, createdByUser: true);
-            return data != null && !data.IsComplete && data.CreatedOn < expiration;
-        }
     }    
 }

--- a/Shared/Phrases.cs
+++ b/Shared/Phrases.cs
@@ -11,16 +11,21 @@ namespace Shared
         public const string ProjectName = "Project TIRA";
         public const string WebsiteUrl = "tira.powerappsportals.com";
 
+        public static string ExceptionMessage = $"Sorry, it looks like something went wrong. If this continues to happen, try sending \"{Keywords.Update}\" to start a new update";
+
+        public static class Keywords
+        {
+            public const string Update = "update";
+            public const string Enable = "enable";
+            public const string Disable = "disable";
+
+            public static string HowToEnable = $"Send \"{Enable}\" to allow the {ProjectName} bot to contact you for your availability";
+            public static string HowToDisable = $"Send \"{Disable}\" to stop the {ProjectName} bot from contacting you for your availability";
+            public static string HowToUpdate = $"Send \"{Update}\" to update your availability";
+        }
+
         public static class Greeting
         {
-            public const string UpdateKeyword = "update";
-            public const string EnableKeyword = "enable";
-            public const string DisableKeyword = "disable";
-
-            public static string Enable = $"Send \"{EnableKeyword}\" to allow the {ProjectName} bot to contact you for your availability";
-            public static string Disable = $"Send \"{DisableKeyword}\" to stop the {ProjectName} bot from contacting you for your availability";
-            public static string Update = $"Send \"{UpdateKeyword}\" to update your availability";
-
             public static Activity NotRegistered = MessageFactory.Text($"It looks like you aren't registered - Visit {WebsiteUrl} to register and link your mobile phone number");
             public static Activity NoOrganization = MessageFactory.Text($"It looks like you aren't connected with an organization. Visit {WebsiteUrl} to register your organization");
             public static Activity UnverifiedOrganization = MessageFactory.Text("It looks like your organization is still pending verification. You will be notified once your organization is verified");
@@ -36,21 +41,21 @@ namespace Shared
                     default: greeting = $"Happy {day.ToString()}{name}!"; break;
                 }
 
-                return MessageFactory.Text(greeting + Environment.NewLine + Update);
+                return MessageFactory.Text(greeting + Environment.NewLine + Keywords.HowToUpdate);
             }
 
-            public static Activity Keywords(User user, bool welcomeUser = false)
+            public static Activity GetKeywords(User user, bool welcomeUser = false)
             {
                 string greeting = welcomeUser ? (Welcome(user) + Environment.NewLine) : string.Empty;
-                greeting += "- " + Update + Environment.NewLine +
-                            "- " + (user.ContactEnabled ? Disable : Enable);
+                greeting += "- " + Keywords.HowToUpdate + Environment.NewLine +
+                            "- " + (user.ContactEnabled ? Keywords.HowToDisable : Keywords.HowToEnable);
 
                 return MessageFactory.Text(greeting);
             }
 
             public static Activity ContactEnabledUpdated(bool contactEnabled)
             {
-                return MessageFactory.Text($"Your contact preference has been updated. " + (contactEnabled ? Disable : Enable));
+                return MessageFactory.Text($"Your contact preference has been updated. " + (contactEnabled ? Keywords.HowToDisable : Keywords.HowToEnable));
             }
 
             private static string Welcome(User user)
@@ -74,27 +79,6 @@ namespace Shared
             public static Activity RetryInvalidCount(int total, Activity retryPrompt)
             {
                 return MessageFactory.Text($"Oops, the openings cannot be more than the total available ({total}). {retryPrompt.Text}");
-            }
-        }
-
-        public static class Reset
-        {
-            public const string Keyword = "reset";
-            public const int TimeoutHours = 12;
-
-            public static Activity Expired(User user)
-            {
-                return MessageFactory.Text($"Unfortunately your update expired after {TimeoutHours} hours.{Environment.NewLine}{Greeting.Keywords(user).Text}");
-            }
-
-            public static Activity Forced(User user)
-            {
-                return MessageFactory.Text($"Forced reset.{Environment.NewLine}{Greeting.Keywords(user).Text}");
-            }
-
-            public static bool ShouldReset(IConfiguration configuration, ITurnContext turnContext)
-            {
-                return !configuration.IsProduction() && string.Equals(turnContext.Activity.Text, Keyword, StringComparison.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
Auto-expiring was too complex - simplified by clearing out the conversation stack any time "update" is sent. That way a user can continue any update as long as they want (with the creation date being when they first started it), but if they respond "update" to a auto-reminder, they can always start a new one 