### PR TITLE
WaitlistIsOpen instead of WaitlistLength

### DIFF
--- a/EntityModel/CaseManagementData.cs
+++ b/EntityModel/CaseManagementData.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System;
 
 namespace EntityModel
 {
@@ -26,7 +25,7 @@ namespace EntityModel
         public bool HasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int WaitlistLength { get; set; }
+        public bool WaitlistIsOpen { get; set; }
 
         public override void CopyStaticValues<T>(T data)
         {

--- a/EntityModel/DbModel.cs
+++ b/EntityModel/DbModel.cs
@@ -36,8 +36,8 @@ namespace EntityModel
         public DbModel CreateDbContext(string[] args)
         {
             // Only used by EF Core Tools, so okay to hardcode to local DB.
-            return Create("Server=(LocalDb)\\MSSQLLocalDB;initial catalog=ProjectTira;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework");
-            //return Create("Server=tcp:project-tira-staging.database.windows.net,1433;Initial Catalog=project-tira-staging;Persist Security Info=False;User ID=project-tira;Password=LamePassword1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;");
+            //return Create("Server=(LocalDb)\\MSSQLLocalDB;initial catalog=ProjectTira;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework");
+            return Create("Server=tcp:project-tira-staging.database.windows.net,1433;Initial Catalog=project-tira-staging;Persist Security Info=False;User ID=project-tira;Password=LamePassword1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;");
         }
 
         public static DbModel Create(string connectionString)

--- a/EntityModel/HousingData.cs
+++ b/EntityModel/HousingData.cs
@@ -25,7 +25,7 @@ namespace EntityModel
         public bool EmergencySharedBedsHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "tira_emergencysharedbedswaitlist")]
-        public int EmergencySharedBedsWaitlistLength { get; set; }
+        public bool EmergencySharedBedsWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "tira_emergencyprivatebedstotal")]
         public int EmergencyPrivateBedsTotal { get; set; }
@@ -37,7 +37,7 @@ namespace EntityModel
         public bool EmergencyPrivateBedsHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "tira_emergencyprivatebedswaitlist")]
-        public int EmergencyPrivateBedsWaitlistLength { get; set; }
+        public bool EmergencyPrivateBedsWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "tira_longtemsharedbedstotal")]
         public int LongTermSharedBedsTotal { get; set; }
@@ -49,7 +49,7 @@ namespace EntityModel
         public bool LongTermSharedBedsHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "tira_longtemsharedbedswaitlist")]
-        public int LongTermSharedBedsWaitlistLength{ get; set; }
+        public bool LongTermSharedBedsWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "tira_longtemprivatebedstotal")]
         public int LongTermPrivateBedsTotal { get; set; }
@@ -61,7 +61,7 @@ namespace EntityModel
         public bool LongTermPrivateBedsHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "tira_longtemprivatebedswaitlist")]
-        public int LongTermPrivateBedsWaitlistLength { get; set; }
+        public bool LongTermPrivateBedsWaitlistIsOpen { get; set; }
 
         public override void CopyStaticValues<T>(T data)
         {

--- a/EntityModel/JobTrainingData.cs
+++ b/EntityModel/JobTrainingData.cs
@@ -25,7 +25,7 @@ namespace EntityModel
         public bool HasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int WaitlistLength { get; set; }
+        public bool WaitlistIsOpen { get; set; }
 
         public override void CopyStaticValues<T>(T data)
         {

--- a/EntityModel/MentalHealthData.cs
+++ b/EntityModel/MentalHealthData.cs
@@ -25,7 +25,7 @@ namespace EntityModel
         public bool InPatientHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int InPatientWaitlistLength { get; set; }
+        public bool InPatientWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
         public int OutPatientTotal { get; set; }
@@ -37,7 +37,7 @@ namespace EntityModel
         public bool OutPatientHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int OutPatientWaitlistLength { get; set; }
+        public bool OutPatientWaitlistIsOpen { get; set; }
 
         public override void CopyStaticValues<T>(T data)
         {

--- a/EntityModel/Migrations/20190822165340_WaitlistIsOpenInsteadOfLength.Designer.cs
+++ b/EntityModel/Migrations/20190822165340_WaitlistIsOpenInsteadOfLength.Designer.cs
@@ -4,14 +4,16 @@ using EntityModel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace EntityModel.Migrations
 {
     [DbContext(typeof(DbModel))]
-    partial class DbModelModelSnapshot : ModelSnapshot
+    [Migration("20190822165340_WaitlistIsOpenInsteadOfLength")]
+    partial class WaitlistIsOpenInsteadOfLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EntityModel/Migrations/20190822165340_WaitlistIsOpenInsteadOfLength.cs
+++ b/EntityModel/Migrations/20190822165340_WaitlistIsOpenInsteadOfLength.cs
@@ -1,0 +1,253 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace EntityModel.Migrations
+{
+    public partial class WaitlistIsOpenInsteadOfLength : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DetoxWaitlistLength",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "GroupWaitlistLength",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "InPatientWaitlistLength",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "OutPatientWaitlistLength",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "InPatientWaitlistLength",
+                table: "MentalHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "OutPatientWaitlistLength",
+                table: "MentalHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "WaitlistLength",
+                table: "JobTrainingData");
+
+            migrationBuilder.DropColumn(
+                name: "EmergencyPrivateBedsWaitlistLength",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "EmergencySharedBedsWaitlistLength",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "LongTermPrivateBedsWaitlistLength",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "LongTermSharedBedsWaitlistLength",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "WaitlistLength",
+                table: "CaseManagementData");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DetoxWaitlistIsOpen",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "GroupWaitlistIsOpen",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "InPatientWaitlistIsOpen",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "OutPatientWaitlistIsOpen",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "InPatientWaitlistIsOpen",
+                table: "MentalHealthData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "OutPatientWaitlistIsOpen",
+                table: "MentalHealthData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "WaitlistIsOpen",
+                table: "JobTrainingData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "EmergencyPrivateBedsWaitlistIsOpen",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "EmergencySharedBedsWaitlistIsOpen",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "LongTermPrivateBedsWaitlistIsOpen",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "LongTermSharedBedsWaitlistIsOpen",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "WaitlistIsOpen",
+                table: "CaseManagementData",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DetoxWaitlistIsOpen",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "GroupWaitlistIsOpen",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "InPatientWaitlistIsOpen",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "OutPatientWaitlistIsOpen",
+                table: "SubstanceUseData");
+
+            migrationBuilder.DropColumn(
+                name: "InPatientWaitlistIsOpen",
+                table: "MentalHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "OutPatientWaitlistIsOpen",
+                table: "MentalHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "WaitlistIsOpen",
+                table: "JobTrainingData");
+
+            migrationBuilder.DropColumn(
+                name: "EmergencyPrivateBedsWaitlistIsOpen",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "EmergencySharedBedsWaitlistIsOpen",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "LongTermPrivateBedsWaitlistIsOpen",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "LongTermSharedBedsWaitlistIsOpen",
+                table: "HousingData");
+
+            migrationBuilder.DropColumn(
+                name: "WaitlistIsOpen",
+                table: "CaseManagementData");
+
+            migrationBuilder.AddColumn<int>(
+                name: "DetoxWaitlistLength",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "GroupWaitlistLength",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "InPatientWaitlistLength",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OutPatientWaitlistLength",
+                table: "SubstanceUseData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "InPatientWaitlistLength",
+                table: "MentalHealthData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OutPatientWaitlistLength",
+                table: "MentalHealthData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WaitlistLength",
+                table: "JobTrainingData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EmergencyPrivateBedsWaitlistLength",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EmergencySharedBedsWaitlistLength",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LongTermPrivateBedsWaitlistLength",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LongTermSharedBedsWaitlistLength",
+                table: "HousingData",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WaitlistLength",
+                table: "CaseManagementData",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/EntityModel/SubstanceUseData.cs
+++ b/EntityModel/SubstanceUseData.cs
@@ -25,7 +25,7 @@ namespace EntityModel
         public bool DetoxHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int DetoxWaitlistLength { get; set; }
+        public bool DetoxWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
         public int InPatientTotal { get; set; }
@@ -37,7 +37,7 @@ namespace EntityModel
         public bool InPatientHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int InPatientWaitlistLength { get; set; }
+        public bool InPatientWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
         public int OutPatientTotal { get; set; }
@@ -49,7 +49,7 @@ namespace EntityModel
         public bool OutPatientHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int OutPatientWaitlistLength { get; set; }
+        public bool OutPatientWaitlistIsOpen { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
         public int GroupTotal { get; set; }
@@ -61,7 +61,7 @@ namespace EntityModel
         public bool GroupHasWaitlist { get; set; }
 
         [JsonProperty(PropertyName = "TODO")]
-        public int GroupWaitlistLength { get; set; }
+        public bool GroupWaitlistIsOpen { get; set; }
 
         public override void CopyStaticValues<T>(T data)
         {

--- a/ServiceProviderBot/Bot/Dialogs/DialogBase.cs
+++ b/ServiceProviderBot/Bot/Dialogs/DialogBase.cs
@@ -95,7 +95,7 @@ namespace ServiceProviderBot.Bot.Dialogs
         }
 
         protected WaterfallStep[] GenerateUpdateSteps<T>(string serviceName, string totalPropertyName, string openPropertyName,
-            string hasWaitlistPropertyName, string waitlistLengthPropertyName) where T : ServiceModelBase, new()
+            string hasWaitlistPropertyName, string waitlistIsOpenPropertyName) where T : ServiceModelBase, new()
         {
             return new WaterfallStep[]
             {
@@ -147,10 +147,10 @@ namespace ServiceProviderBot.Bot.Dialogs
                         var hasWaitlist = (bool)typeof(T).GetProperty(hasWaitlistPropertyName).GetValue(data);
                         if (hasWaitlist && open == 0)
                         {
-                            // Prompt for the waitlist length.
+                            // Prompt for if the waitlist is open.
                             return await stepContext.PromptAsync(
-                                Prompt.IntPrompt,
-                                new PromptOptions { Prompt = Phrases.Capacity.GetWaitlistLength(serviceName) },
+                                Prompt.ConfirmPrompt,
+                                new PromptOptions { Prompt = Phrases.Capacity.GetWaitlistIsOpen(serviceName) },
                                 cancellationToken);
                         }
                     }
@@ -165,7 +165,7 @@ namespace ServiceProviderBot.Bot.Dialogs
                     {
                         // Get the latest snapshot created by the user and update it.
                         var data = await this.api.GetLatestServiceData<T>(this.userToken, createdByUser: true);
-                        typeof(T).GetProperty(waitlistLengthPropertyName).SetValue(data, (int)stepContext.Result);
+                        typeof(T).GetProperty(waitlistIsOpenPropertyName).SetValue(data, (bool)stepContext.Result);
                         await this.api.Update(data);
                     }
 

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateCaseManagementDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateCaseManagementDialog.cs
@@ -21,7 +21,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
             steps.Add(GenerateCreateDataStep<CaseManagementData>());
 
             steps.AddRange(GenerateUpdateSteps<CaseManagementData>(Phrases.Services.CaseManagement.ServiceName, nameof(CaseManagementData.Total),
-                nameof(CaseManagementData.Open), nameof(CaseManagementData.HasWaitlist), nameof(CaseManagementData.WaitlistLength)));
+                nameof(CaseManagementData.Open), nameof(CaseManagementData.HasWaitlist), nameof(CaseManagementData.WaitlistIsOpen)));
 
             steps.Add(GenerateCompleteDataStep<CaseManagementData>());
 

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateHousingDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateHousingDialog.cs
@@ -22,16 +22,16 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
             steps.Add(GenerateCreateDataStep<HousingData>());
 
             steps.AddRange(GenerateUpdateSteps<HousingData>(Phrases.Services.Housing.EmergencySharedBeds, nameof(HousingData.EmergencySharedBedsTotal),
-                nameof(HousingData.EmergencySharedBedsOpen), nameof(HousingData.EmergencySharedBedsHasWaitlist), nameof(HousingData.EmergencySharedBedsWaitlistLength)));
+                nameof(HousingData.EmergencySharedBedsOpen), nameof(HousingData.EmergencySharedBedsHasWaitlist), nameof(HousingData.EmergencySharedBedsWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<HousingData>(Phrases.Services.Housing.EmergencyPrivateBeds, nameof(HousingData.EmergencyPrivateBedsTotal),
-                nameof(HousingData.EmergencyPrivateBedsOpen), nameof(HousingData.EmergencyPrivateBedsHasWaitlist), nameof(HousingData.EmergencyPrivateBedsWaitlistLength)));
+                nameof(HousingData.EmergencyPrivateBedsOpen), nameof(HousingData.EmergencyPrivateBedsHasWaitlist), nameof(HousingData.EmergencyPrivateBedsWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<HousingData>(Phrases.Services.Housing.LongTermSharedBeds, nameof(HousingData.LongTermSharedBedsTotal),
-                nameof(HousingData.LongTermSharedBedsOpen), nameof(HousingData.LongTermSharedBedsHasWaitlist), nameof(HousingData.LongTermSharedBedsWaitlistLength)));
+                nameof(HousingData.LongTermSharedBedsOpen), nameof(HousingData.LongTermSharedBedsHasWaitlist), nameof(HousingData.LongTermSharedBedsWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<HousingData>(Phrases.Services.Housing.LongTermPrivateBeds, nameof(HousingData.LongTermPrivateBedsTotal),
-                nameof(HousingData.LongTermPrivateBedsOpen), nameof(HousingData.LongTermPrivateBedsHasWaitlist), nameof(HousingData.LongTermPrivateBedsWaitlistLength)));
+                nameof(HousingData.LongTermPrivateBedsOpen), nameof(HousingData.LongTermPrivateBedsHasWaitlist), nameof(HousingData.LongTermPrivateBedsWaitlistIsOpen)));
 
             steps.Add(GenerateCompleteDataStep<HousingData>());
 

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateJobTrainingDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateJobTrainingDialog.cs
@@ -21,7 +21,7 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
             steps.Add(GenerateCreateDataStep<JobTrainingData>());
 
             steps.AddRange(GenerateUpdateSteps<JobTrainingData>(Phrases.Services.JobTraining.ServiceName, nameof(JobTrainingData.Total),
-                nameof(JobTrainingData.Open), nameof(JobTrainingData.HasWaitlist), nameof(JobTrainingData.WaitlistLength)));
+                nameof(JobTrainingData.Open), nameof(JobTrainingData.HasWaitlist), nameof(JobTrainingData.WaitlistIsOpen)));
 
             steps.Add(GenerateCompleteDataStep<JobTrainingData>());
 

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateMentalHealthDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateMentalHealthDialog.cs
@@ -21,10 +21,10 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
             steps.Add(GenerateCreateDataStep<MentalHealthData>());
 
             steps.AddRange(GenerateUpdateSteps<MentalHealthData>(Phrases.Services.MentalHealth.InPatient, nameof(MentalHealthData.InPatientTotal),
-                nameof(MentalHealthData.InPatientOpen), nameof(MentalHealthData.InPatientHasWaitlist), nameof(MentalHealthData.InPatientWaitlistLength)));
+                nameof(MentalHealthData.InPatientOpen), nameof(MentalHealthData.InPatientHasWaitlist), nameof(MentalHealthData.InPatientWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<MentalHealthData>(Phrases.Services.MentalHealth.OutPatient, nameof(MentalHealthData.OutPatientTotal),
-                nameof(MentalHealthData.OutPatientOpen), nameof(MentalHealthData.OutPatientHasWaitlist), nameof(MentalHealthData.OutPatientWaitlistLength)));
+                nameof(MentalHealthData.OutPatientOpen), nameof(MentalHealthData.OutPatientHasWaitlist), nameof(MentalHealthData.OutPatientWaitlistIsOpen)));
 
             steps.Add(GenerateCompleteDataStep<MentalHealthData>());
 

--- a/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateSubstanceUseDialog.cs
+++ b/ServiceProviderBot/Bot/Dialogs/UpdateOrganization/Capacity/UpdateSubstanceUseDialog.cs
@@ -21,16 +21,16 @@ namespace ServiceProviderBot.Bot.Dialogs.UpdateOrganization.Capacity
             steps.Add(GenerateCreateDataStep<SubstanceUseData>());
 
             steps.AddRange(GenerateUpdateSteps<SubstanceUseData>(Phrases.Services.SubstanceUse.Detox, nameof(SubstanceUseData.DetoxTotal),
-                nameof(SubstanceUseData.DetoxOpen), nameof(SubstanceUseData.DetoxHasWaitlist), nameof(SubstanceUseData.DetoxWaitlistLength)));
+                nameof(SubstanceUseData.DetoxOpen), nameof(SubstanceUseData.DetoxHasWaitlist), nameof(SubstanceUseData.DetoxWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<SubstanceUseData>(Phrases.Services.SubstanceUse.InPatient, nameof(SubstanceUseData.InPatientTotal),
-                nameof(SubstanceUseData.InPatientOpen), nameof(SubstanceUseData.InPatientHasWaitlist), nameof(SubstanceUseData.InPatientWaitlistLength)));
+                nameof(SubstanceUseData.InPatientOpen), nameof(SubstanceUseData.InPatientHasWaitlist), nameof(SubstanceUseData.InPatientWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<SubstanceUseData>(Phrases.Services.SubstanceUse.OutPatient, nameof(SubstanceUseData.OutPatientTotal),
-                nameof(SubstanceUseData.OutPatientOpen), nameof(SubstanceUseData.OutPatientHasWaitlist), nameof(SubstanceUseData.OutPatientWaitlistLength)));
+                nameof(SubstanceUseData.OutPatientOpen), nameof(SubstanceUseData.OutPatientHasWaitlist), nameof(SubstanceUseData.OutPatientWaitlistIsOpen)));
 
             steps.AddRange(GenerateUpdateSteps<SubstanceUseData>(Phrases.Services.SubstanceUse.Group, nameof(SubstanceUseData.GroupTotal),
-                nameof(SubstanceUseData.GroupOpen), nameof(SubstanceUseData.GroupHasWaitlist), nameof(SubstanceUseData.GroupWaitlistLength)));
+                nameof(SubstanceUseData.GroupOpen), nameof(SubstanceUseData.GroupHasWaitlist), nameof(SubstanceUseData.GroupWaitlistIsOpen)));
 
             steps.Add(GenerateCompleteDataStep<SubstanceUseData>());
 

--- a/Shared/Helpers.cs
+++ b/Shared/Helpers.cs
@@ -1,6 +1,5 @@
 ﻿using EntityModel;
 using Microsoft.Bot.Builder;
-using Shared.ApiInterface;
 using System.Diagnostics;
 
 namespace Shared
@@ -79,6 +78,22 @@ namespace Shared
                 case ServiceType.SubstanceUse: return SubstanceUseData.PRIMARY_KEY;
                 default: return string.Empty;
             }
-        }       
+        }
+
+        /// <summary>
+        /// Gets the name for a service.
+        /// </summary>
+        public static string GetServiceName(ServiceType serviceType)
+        {
+            switch (serviceType)
+            {
+                case ServiceType.CaseManagement: return Phrases.Services.CaseManagement.ServiceName;
+                case ServiceType.Housing: return Phrases.Services.Housing.ServiceName;
+                case ServiceType.JobTraining: return Phrases.Services.JobTraining.ServiceName;
+                case ServiceType.MentalHealth: return Phrases.Services.MentalHealth.ServiceName;
+                case ServiceType.SubstanceUse: return Phrases.Services.SubstanceUse.ServiceName;
+                default: return string.Empty;
+            }
+        }
     }
 }

--- a/Shared/Phrases.cs
+++ b/Shared/Phrases.cs
@@ -74,9 +74,9 @@ namespace Shared
                 return MessageFactory.Text($"How many openings do you have for {serviceName}?");
             }
 
-            public static Activity GetWaitlistLength(string serviceName)
+            public static Activity GetWaitlistIsOpen(string serviceName)
             {
-                return MessageFactory.Text($"How long is your waitlist for {serviceName}?");
+                return MessageFactory.Text($"Is your waitlist open for {serviceName}?");
             }
 
             public static Activity RetryInvalidCount(int total, Activity retryPrompt)

--- a/Shared/TestHelpers.cs
+++ b/Shared/TestHelpers.cs
@@ -9,7 +9,7 @@ namespace Shared
     {
         public static int DefaultTotal = 10;
         public static int DefaultOpen = 5;
-        public static int DefaultWaitlistLength = 1;
+        public static bool DefaultWaitlistIsOpen = true;
 
         public static async Task<Organization> CreateOrganization(IApiInterface api, bool isVerified)
         {

--- a/Tests/Dialogs/UpdateOrganization/Capacity/UpdateCaseManagementDialogTests.cs
+++ b/Tests/Dialogs/UpdateOrganization/Capacity/UpdateCaseManagementDialogTests.cs
@@ -38,14 +38,14 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
 
             await CreateTestFlow(UpdateCaseManagementDialog.Name, user)
                 .Test("test", Phrases.Capacity.GetOpenings(Phrases.Services.CaseManagement.ServiceName))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.CaseManagement.ServiceName))
-                .Send(TestHelpers.DefaultWaitlistLength.ToString())
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.CaseManagement.ServiceName)))
+                .Send(TestHelpers.DefaultWaitlistIsOpen.ToString())
                 .StartTestAsync();
 
             // Validate the results.
             var resultData = await this.api.GetLatestServiceData<CaseManagementData>(this.userToken, true);
             Assert.Equal(0, resultData.Open);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.WaitlistLength);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.WaitlistIsOpen);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             // Validate the results.
             var resultData = await this.api.GetLatestServiceData<CaseManagementData>(this.userToken, true);
             Assert.Equal(0, resultData.Open);
-            Assert.Equal(0, resultData.WaitlistLength);
+            Assert.False(resultData.WaitlistIsOpen);
         }
     }
 }

--- a/Tests/Dialogs/UpdateOrganization/Capacity/UpdateHousingDialogTests.cs
+++ b/Tests/Dialogs/UpdateOrganization/Capacity/UpdateHousingDialogTests.cs
@@ -44,14 +44,14 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
 
             await CreateTestFlow(UpdateHousingDialog.Name, user)
                 .Test("test", Phrases.Capacity.GetOpenings(Phrases.Services.Housing.EmergencySharedBeds))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.Housing.EmergencySharedBeds))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.Housing.EmergencyPrivateBeds))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.Housing.EmergencyPrivateBeds))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.Housing.LongTermSharedBeds))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.Housing.LongTermSharedBeds))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.Housing.LongTermPrivateBeds))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.Housing.LongTermPrivateBeds))
-                .Send(TestHelpers.DefaultWaitlistLength.ToString())
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.Housing.EmergencySharedBeds)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.Housing.EmergencyPrivateBeds))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.Housing.EmergencyPrivateBeds)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.Housing.LongTermSharedBeds))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.Housing.LongTermSharedBeds)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.Housing.LongTermPrivateBeds))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.Housing.LongTermPrivateBeds)))
+                .Send(TestHelpers.DefaultWaitlistIsOpen.ToString())
                 .StartTestAsync();
 
             // Validate the results.
@@ -60,10 +60,10 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             Assert.Equal(0, resultData.EmergencyPrivateBedsOpen);
             Assert.Equal(0, resultData.LongTermSharedBedsOpen);
             Assert.Equal(0, resultData.LongTermPrivateBedsOpen);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.EmergencySharedBedsWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.EmergencyPrivateBedsWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.LongTermSharedBedsWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.LongTermPrivateBedsWaitlistLength);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.EmergencySharedBedsWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.LongTermPrivateBedsWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.LongTermSharedBedsWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.LongTermPrivateBedsWaitlistIsOpen);
         }
 
         [Fact]
@@ -89,6 +89,10 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             Assert.Equal(0, resultData.EmergencyPrivateBedsOpen);
             Assert.Equal(0, resultData.LongTermSharedBedsOpen);
             Assert.Equal(0, resultData.LongTermPrivateBedsOpen);
+            Assert.False(resultData.EmergencySharedBedsWaitlistIsOpen);
+            Assert.False(resultData.EmergencyPrivateBedsWaitlistIsOpen);
+            Assert.False(resultData.LongTermSharedBedsWaitlistIsOpen);
+            Assert.False(resultData.LongTermPrivateBedsWaitlistIsOpen);
         }
     }
 }

--- a/Tests/Dialogs/UpdateOrganization/Capacity/UpdateJobTrainingDialogTests.cs
+++ b/Tests/Dialogs/UpdateOrganization/Capacity/UpdateJobTrainingDialogTests.cs
@@ -39,14 +39,14 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
 
             await CreateTestFlow(UpdateJobTrainingDialog.Name, user)
                 .Test("test", Phrases.Capacity.GetOpenings(Phrases.Services.JobTraining.ServiceName))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.JobTraining.ServiceName))
-                .Send(TestHelpers.DefaultWaitlistLength.ToString())
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.JobTraining.ServiceName)))
+                .Send(TestHelpers.DefaultWaitlistIsOpen.ToString())
                 .StartTestAsync();
 
             // Validate the results.
             var resultData = await this.api.GetLatestServiceData<JobTrainingData>(this.userToken, true);
             Assert.Equal(0, resultData.Open);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.WaitlistLength);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.WaitlistIsOpen);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             // Validate the results.
             var resultData = await this.api.GetLatestServiceData<JobTrainingData>(this.userToken, true);
             Assert.Equal(0, resultData.Open);
-            Assert.Equal(0, resultData.WaitlistLength);
+            Assert.False(resultData.WaitlistIsOpen);
         }
     }
 }

--- a/Tests/Dialogs/UpdateOrganization/Capacity/UpdateMentalHealthDialogTests.cs
+++ b/Tests/Dialogs/UpdateOrganization/Capacity/UpdateMentalHealthDialogTests.cs
@@ -41,18 +41,18 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
 
             await CreateTestFlow(UpdateMentalHealthDialog.Name, user)
                 .Test("test", Phrases.Capacity.GetOpenings(Phrases.Services.MentalHealth.InPatient))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.MentalHealth.InPatient))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.MentalHealth.OutPatient))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.MentalHealth.OutPatient))
-                .Send(TestHelpers.DefaultWaitlistLength.ToString())
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.MentalHealth.InPatient)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.MentalHealth.OutPatient))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.MentalHealth.OutPatient)))
+                .Send(TestHelpers.DefaultWaitlistIsOpen.ToString())
                 .StartTestAsync();
 
             // Validate the results.
             var resultData = await this.api.GetLatestServiceData<MentalHealthData>(this.userToken, true);
             Assert.Equal(0, resultData.InPatientOpen);
             Assert.Equal(0, resultData.OutPatientOpen);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.InPatientWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.OutPatientWaitlistLength);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.InPatientWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.OutPatientWaitlistIsOpen);
         }
 
         [Fact]
@@ -74,6 +74,8 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             var resultData = await this.api.GetLatestServiceData<MentalHealthData>(this.userToken, true);
             Assert.Equal(0, resultData.InPatientOpen);
             Assert.Equal(0, resultData.OutPatientOpen);
+            Assert.False(resultData.InPatientWaitlistIsOpen);
+            Assert.False(resultData.OutPatientWaitlistIsOpen);
         }
     }
 }

--- a/Tests/Dialogs/UpdateOrganization/Capacity/UpdateSubstanceUseDialogTests.cs
+++ b/Tests/Dialogs/UpdateOrganization/Capacity/UpdateSubstanceUseDialogTests.cs
@@ -45,14 +45,14 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
 
             await CreateTestFlow(UpdateSubstanceUseDialog.Name, user)
                 .Test("test", Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.Detox))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.SubstanceUse.Detox))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.InPatient))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.SubstanceUse.InPatient))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.OutPatient))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.SubstanceUse.OutPatient))
-                .Test(TestHelpers.DefaultWaitlistLength.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.Group))
-                .Test("0", Phrases.Capacity.GetWaitlistLength(Phrases.Services.SubstanceUse.Group))
-                .Send(TestHelpers.DefaultWaitlistLength.ToString())
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.SubstanceUse.Detox)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.InPatient))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.SubstanceUse.InPatient)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.OutPatient))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.SubstanceUse.OutPatient)))
+                .Test(TestHelpers.DefaultWaitlistIsOpen.ToString(), Phrases.Capacity.GetOpenings(Phrases.Services.SubstanceUse.Group))
+                .Test("0", StartsWith(Phrases.Capacity.GetWaitlistIsOpen(Phrases.Services.SubstanceUse.Group)))
+                .Send(TestHelpers.DefaultWaitlistIsOpen.ToString())
                 .StartTestAsync();
 
             // Validate the results.
@@ -61,10 +61,10 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             Assert.Equal(0, resultData.InPatientOpen);
             Assert.Equal(0, resultData.OutPatientOpen);
             Assert.Equal(0, resultData.GroupOpen);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.DetoxWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.InPatientWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.OutPatientWaitlistLength);
-            Assert.Equal(TestHelpers.DefaultWaitlistLength, resultData.GroupWaitlistLength);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.DetoxWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.InPatientWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.OutPatientWaitlistIsOpen);
+            Assert.Equal(TestHelpers.DefaultWaitlistIsOpen, resultData.GroupWaitlistIsOpen);
         }
 
         [Fact]
@@ -90,6 +90,10 @@ namespace Tests.Dialogs.UpdateOrganization.Capacity
             Assert.Equal(0, resultData.InPatientOpen);
             Assert.Equal(0, resultData.OutPatientOpen);
             Assert.Equal(0, resultData.GroupOpen);
+            Assert.False(resultData.DetoxWaitlistIsOpen);
+            Assert.False(resultData.InPatientWaitlistIsOpen);
+            Assert.False(resultData.OutPatientWaitlistIsOpen);
+            Assert.False(resultData.GroupWaitlistIsOpen);
         }
     }
 }


### PR DESCRIPTION
Based on feedback from Amanda, changing WaitlistLength to WaitlistIsOpen.

"Though the information on how long is helpful, some orgs just open waitlists until they have five or 10 names and then they close it so it's not a standard applicaiton."